### PR TITLE
ci: release 0.4.0 and auto-release dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,12 @@ updates:
       - "wadahiro"
     assignees:
       - "wadahiro"
+    # Use the `fix` type so dependency/security updates are recognized by
+    # release-please as patch releases. cargo can't split dev/prod prefixes
+    # (prefix-development is unsupported for cargo), so dev-dependency bumps
+    # also produce a patch release — an accepted trade-off for staying current.
     commit-message:
-      prefix: "deps"
+      prefix: "fix"
       include: "scope"
 
   # Enable version updates for GitHub Actions


### PR DESCRIPTION
Two related changes:

1. **Auto-release dependency updates** — switch the cargo Dependabot commit prefix from `deps` to `fix` (→ `fix(deps):`) so dependency/security updates are recognized by release-please as **patch** releases.
   - cargo can't split dev/prod prefixes (`commit-message.prefix-development` is unsupported for cargo per [GitHub docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference)), so dev-dependency bumps will also cut patch releases — accepted trade-off for staying current.
   - github-actions keeps the non-releasing `ci` prefix (CI-only, never ships).

2. **Force-release the accumulated work as 0.4.0** — via a `Release-As: 0.4.0` footer. Everything since v0.3.0 (security dependency updates, multi-arch GHCR images, macOS/Windows binaries, the `--version` fix) had `deps`/`ci` types that don't bump on their own, so release-please needs the explicit override. Minor bump because of the new distribution targets.

## ⚠️ Required ordering
`RELEASE_PLEASE_TOKEN` **must be set before this merges** (Settings → Secrets and variables → Actions). Otherwise the release-please run fails (as it did on the last main push) and no Release PR is created — you'd then just re-run it after adding the token.

## What happens after merge (with the token set)
1. release-please opens a **Release PR** for **0.4.0** (bumps Cargo.toml/Cargo.lock, writes CHANGELOG.md).
2. Merge that Release PR → tag `v0.4.0` + published GitHub Release.
3. `release.yml` fires → builds the 6 binaries + license bundle + multi-arch GHCR image and attaches them.
4. One-time: flip the GHCR package to public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)