### PR TITLE
build(docker): upgrade Alpine runtime to 3.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ COPY src ./src
 RUN cargo build --release --locked --features "${FEATURES}"
 
 # Runtime stage
-FROM alpine:3.21
+FROM alpine:3.24
 
 # Install runtime dependencies
 RUN apk add --no-cache \

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,20 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "include-component-in-tag": false,
+  "changelog-sections": [
+    { "type": "feat", "section": "Features" },
+    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "perf", "section": "Performance Improvements" },
+    { "type": "deps", "section": "Dependencies" },
+    { "type": "build", "section": "Build System" },
+    { "type": "revert", "section": "Reverts" },
+    { "type": "docs", "section": "Documentation", "hidden": true },
+    { "type": "style", "section": "Styles", "hidden": true },
+    { "type": "chore", "section": "Miscellaneous", "hidden": true },
+    { "type": "refactor", "section": "Code Refactoring", "hidden": true },
+    { "type": "test", "section": "Tests", "hidden": true },
+    { "type": "ci", "section": "Continuous Integration", "hidden": true }
+  ],
   "packages": {
     ".": {
       "release-type": "rust"


### PR DESCRIPTION
Part of the 0.4.0 release.

- **Upgrade the Docker runtime base image from `alpine:3.21` to `alpine:3.24`** (current latest stable; `alpine:latest` resolves to 3.24). Runtime packages (`ca-certificates`, `libgcc`, `libpq`, `sqlite-libs`) confirmed available on 3.24.
- **Add release-please `changelog-sections`** so the changelog surfaces Features / Bug Fixes / Dependencies / Build System and hides ci/chore/docs/etc.
- The commit carries a `BEGIN_COMMIT_OVERRIDE` block: the GHCR/multi-platform/dual-backend work since v0.3.0 was committed under `ci:` (hidden by default), so the override restores it to the 0.4.0 notes. Dependency/security details are left to the real `deps:` commit to avoid duplication.

## Flow
1. Merge this → release-please regenerates the **0.4.0 Release PR (#53)** including this change and the corrected notes.
2. Verify the regenerated CHANGELOG looks right, then merge the Release PR → `v0.4.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)