### PR TITLE
ci: drive release-please with a GitHub App token (replaces PAT)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,10 +18,20 @@ jobs:
     name: Release PR / Release
     runs-on: ubuntu-latest
     steps:
+      # Mint a short-lived GitHub App installation token. A non-GITHUB_TOKEN is
+      # required: releases/tags created with the default GITHUB_TOKEN do not
+      # trigger other workflows, so release.yml would never fire. The App needs
+      # Contents: read & write and Pull requests: read & write, and must be
+      # installed on this repo. APP_ID / APP_PRIVATE_KEY are the shared App's
+      # credentials (the same App used by other repos).
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Run release-please
         uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
         with:
-          # A PAT (or GitHub App token) is required — releases created with the
-          # default GITHUB_TOKEN do not trigger other workflows, so release.yml
-          # would never fire. See README for the required token + scopes.
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Switch the release-please token from a personal access token (`RELEASE_PLEASE_TOKEN`) to a short-lived **GitHub App** installation token, minted with `actions/create-github-app-token` — mirroring the setup in `maven-semantic-release-sample`, reusing the **same shared App**.

## Why (recommended over PAT)
- Not tied to a personal account (survives PAT deletion / person leaving)
- Tokens auto-expire (~1h) → smaller leak window
- Least-privilege, repo-scoped permissions
- No expiry-rotation breakage (PATs silently lapse and break the pipeline)
- One shared App drives releases across repos; shows as a bot identity

## Change
`release-please.yml` now generates an App token and passes it to release-please (instead of `secrets.RELEASE_PLEASE_TOKEN`). A non-`GITHUB_TOKEN` is still required so the created release triggers `release.yml`.

## ⚠️ One-time setup required before merging
1. **Install the shared App on `wadahiro/scim-server`** (App settings → Install → add this repo).
2. Ensure the App has **Contents: read & write** and **Pull requests: read & write**.
3. Add repo secrets **`APP_ID`** and **`APP_PRIVATE_KEY`** (same values as in `maven-semantic-release-sample`).
4. After verifying a release-please run succeeds, delete the now-unused **`RELEASE_PLEASE_TOKEN`** secret.

(Do not merge until 1–3 are done, or the next release-please run will fail with an empty App token.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)