### PR TITLE
fix(sqlite): create the database file automatically (no ?mode=rwc needed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,10 @@ backend:
   type: "database"
   database:
     type: "sqlite"  # or "postgresql"
-    url: "scim.db"
+    # SQLite: ":memory:" (ephemeral, used by the zero-config default) or a file
+    # path such as "sqlite:/data/scim.db". A missing file is created
+    # automatically. PostgreSQL: "postgresql://user:pass@host:5432/scim".
+    url: "sqlite:/data/scim.db"
 
 tenants:
   # Simple path-only tenant (matches any host) - OAuth 2.0 Bearer Token

--- a/src/backend/database/sqlite/backend_impl.rs
+++ b/src/backend/database/sqlite/backend_impl.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
-use sqlx::sqlite::SqlitePoolOptions;
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use sqlx::SqlitePool;
+use std::str::FromStr;
 use std::time::Duration;
 
 use super::super::config::DatabaseBackendConfig;
@@ -115,11 +116,23 @@ impl Backend for SqliteBackend {
             .validate()
             .map_err(|e| AppError::Internal(format!("Invalid backend config: {}", e)))?;
 
-        // Create connection pool
+        // Create connection pool. Parse the path into options so we can enable
+        // create_if_missing: without it sqlx refuses to open a non-existent
+        // database file ("unable to open database file"), forcing users to add
+        // `?mode=rwc` to the URL. (:memory: is unaffected.)
+        let options = SqliteConnectOptions::from_str(&config.connection_path)
+            .map_err(|e| {
+                AppError::Database(format!(
+                    "Invalid SQLite connection string '{}': {}",
+                    config.connection_path, e
+                ))
+            })?
+            .create_if_missing(true);
+
         let pool = SqlitePoolOptions::new()
             .max_connections(config.max_connections)
             .acquire_timeout(Duration::from_secs(config.connection_timeout))
-            .connect(&config.connection_path)
+            .connect_with(options)
             .await
             .map_err(|e| AppError::Database(format!("Failed to connect to SQLite: {}", e)))?;
 


### PR DESCRIPTION
## Problem
With a **file-based SQLite** config, the server failed at startup with `unable to open database file` (SQLite code 14) — e.g. `url: "sqlite:/data/scim.db"`. The backend passed the URL straight to sqlx, and sqlx's `create_if_missing` defaults to **false**, so a non-existent DB file isn't created unless you add `?mode=rwc` to the URL. `:memory:` (the zero-config default) was unaffected, which made this an easy footgun.

(Not a permission issue — `/tmp` and the image's `/data` are both writable by the non-root user; the cause was purely the missing create flag.)

## Fix
Parse the connection string into `SqliteConnectOptions` and set `create_if_missing(true)`, so a file path is created automatically on first run. `:memory:` behaves exactly as before.

```rust
let options = SqliteConnectOptions::from_str(&config.connection_path)?
    .create_if_missing(true);
SqlitePoolOptions::new()...connect_with(options).await?
```

Also documented the SQLite `url` formats in the README (`:memory:` vs `sqlite:/path`).

## Verified
- zero-config (`:memory:`) container still works (`docker run -p 3000:3000 IMAGE` → User POST 201).
- file URL **without** `?mode=rwc` now creates the DB and serves CRUD (POST 201).
- full SQLite + PostgreSQL (TestContainers) test suite passes, no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)